### PR TITLE
Fix/incorrect page deploy variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: javadoc
           java-version: 17
+          target-folder: javadoc 
 ```
 
 ### GitHub page

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Branch where the javadoc is hosted'
     required: true
     default: javadoc
+  target-folder: # target folder for the javadoc contents
+    description: 'Directory where the javadoc contents should be stored'
+    required: true
+    default: .
  
 runs:
   using: "composite"
@@ -32,8 +36,8 @@ runs:
   - name: Deploy 🚀
     uses: JamesIves/github-pages-deploy-action@4.1.8
     with:
-      GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-      BRANCH: ${{ inputs.javadoc-branch }}
-      CLEAN: true
-      FOLDER: target/site/apidocs
-      TARGET_FOLDER: javadoc
+      token: ${{ inputs.GITHUB_TOKEN }}
+      branch: ${{ inputs.javadoc-branch }}
+      clean: true
+      folder: target/site/apidocs
+      target-folder: ${{ inputs.target-folder }} 

--- a/exemple-javadoc-publisher.yml
+++ b/exemple-javadoc-publisher.yml
@@ -16,4 +16,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: javadoc
           java-version: 17
-          target-folder: .
+          target-folder: javadoc

--- a/exemple-javadoc-publisher.yml
+++ b/exemple-javadoc-publisher.yml
@@ -16,3 +16,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: javadoc
           java-version: 17
+          target-folder: .


### PR DESCRIPTION
There seems to be some issues with the variable names for the page deploy action. 

`Unexpected input(s) 'GITHUB_TOKEN', 'TARGET_FOLDER', valid inputs are ['ssh-key', 'token', 'branch', 'folder', 'target-folder', 'commit-message', 'clean', 'clean-exclude', 'dry-run', 'git-config-name', 'git-config-email', 'repository-name', 'workspace', 'single-commit', 'silent']`

The result is that the contents from javadoc is placed in the root directory of the chosen branch instead of creating the target-folder. 

This fix adds the ability for users to specify their own target folder as well. The default has been set to the root directory to avoid breaking previous version which should have defaulted to the root directory.

I have tested with `target-folder: .`, `target-folder: javadoc`, and no specified target-folder.
`target-folder: .` and no specified target-folder both added the contents to the root directory.
`target-folder: javadoc` added the contents to the javadoc directory. 

Hope this fix and additional feature is of use for this project.