### PR TITLE
Add dependabot for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Dependabot checks in a weekly interval for updates of Github Actions used in this repository and creates corresponding pull requests.