### PR TITLE
Fix javadoc generation for aggregator projects

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: Generate Javadoc with Maven
       if: inputs.project == 'maven' && inputs.custom-command == ''
-      run: mvn javadoc:javadoc
+      run: mvn javadoc:aggregate
       shell: bash
 
     - name: Generate Javadoc with Gradle


### PR DESCRIPTION
Commit e4e88da4c9bc322578b88e0a6c775d389a39c397 changes the behaviour of the Apache javadoc plugin to the standard Maven goal. This works well for simple maven projects but fails on aggregator projects. This commit reverts to the old behaviour and uses the goal `javadoc:aggregate`.

Closes issue #26.