### PR TITLE
feat(devcontainer): add required extensions for local development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
       "extensions": [
 		"GitHub.copilot",
 		"GitHub.copilot-labs",
-		"cschleiden.vscode-github-actions",
+		"github.vscode-github-actions",
 		"redhat.vscode-yaml"
 	]
     }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+      "github.vscode-github-actions",
+      "redhat.vscode-yaml"
+    ]
+  }


### PR DESCRIPTION
I updated the devcontainer configuration to include the necessary extensions for local development in Visual Studio Code. Specifically, I migrated from the `cschleiden.vscode-github-actions` plugin to [github.vscode-github-actions](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions) since the former was moved to GitHub and devcontainer/vscode couldn't find it (that's why I was able to see the `type`/`options` syntax problem, I have the official plugin locally)

Changes in this pull request:
- Added the required extensions for local development.
- Updated the devcontainer configuration to use the new extension.