### PR TITLE
fix(#93): Use Gradle's default output folder in gradle projects

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,30 +87,32 @@ runs:
       run: ${{ inputs.custom-command }}
       shell: bash
 
+    - name: Set Javadoc source folder
+    id: set-javadoc-source-folder
+    run: |
+      if [ ${{ inputs.project }} == "gradle"  && ${{ inputs.javadoc-source-folder }} == "target/site/apidocs" ]; then
+        echo "javadoc-source-folder=build/docs/javadoc" >> "$GITHUB_OUTPUT"
+      else
+        echo "javadoc-source-folder=${{ inputs.javadoc-source-folder }}" >> "$GITHUB_OUTPUT"
+      fi
+    shell: bash
+
     - name: Handle subdirectories for GitHub Pages
       if: ${{ inputs.subdirectories != '' }}
       run: |
-        if [ ! -d ${{ inputs.javadoc-source-folder }}]; then
-          mkdir -p ${{ inputs.javadoc-source-folder }}
+        source_folder=${{ steps.set-source_folder.outputs.javadoc-source-folder }}
+        
+        if [ ! -d $source_folder ]; then
+          mkdir -p $source_folder
         fi
         dirs=$(echo ${{ inputs.subdirectories }} | tr " " "\n")
         
         for dir in $dirs
         do
-          mkdir -p ${{ inputs.javadoc-source-folder }}/$dir
-          cp -r $dir/${{ inputs.javadoc-source-folder }} ${{ inputs.javadoc-source-folder }}/$dir
+          mkdir -p $source_folder/$dir
+          cp -r $dir/$source_folder $source_folder/$dir
         done
-        ls -R ${{ inputs.javadoc-source-folder }}
-      shell: bash
-
-    - name: Set Javadoc source folder
-      id: set-javadoc-source-folder
-      run: |
-        if [ ${{ inputs.project }} == "gradle"  && ${{ inputs.javadoc-source-folder }} == "target/site/apidocs" ]; then
-          echo "javadoc-source-folder=build/docs/javadoc" >> "$GITHUB_OUTPUT"
-        else
-          echo "javadoc-source-folder=${{ inputs.javadoc-source-folder }}" >> "$GITHUB_OUTPUT"
-        fi
+        ls -R $source_folder
       shell: bash
 
     - name: Deploy to GitHub Page Branch 🚀


### PR DESCRIPTION
Applied the mitigation that appeared for Gradle after the subdirectory handling for the subdirectories too.

This is just a proposal, as it is a bit error-prone to have the input value and the step output value too for the `javadoc-source-folder` variable, it can be easily missed which one should be used in future development.